### PR TITLE
Improved approach to promotion producing dramatically different results

### DIFF
--- a/control.py
+++ b/control.py
@@ -67,9 +67,7 @@ class Control:
                 women_averager.add(result.women[level])
 
             total_employees = men_averager.get_total() + women_averager.get_total()
-            men_avg = men_averager.get_average()
             men_percentage = 100 * men_averager.get_total() / total_employees
-            women_avg = women_averager.get_average()
             women_percentage = 100 * women_averager.get_total() / total_employees
 
             men_append(men_percentage)
@@ -98,10 +96,68 @@ class Control:
 #         """get average of numbers list"""
 #         return self.total / float(len(self.numbers))
 
+    # def print_summary(self):
+    #     """Print summary"""
+    #     print("Level\tMen\tWomen")
+    #     print("%\t\t%")
+    #     print("-----\t-----------------")
+
+    #     men_data = []
+    #     women_data = []
+    #     men_append = men_data.append
+    #     women_append = women_data.append
+
+    #     for level in range(0, self.num_levels):
+    #         men_averager = Averager()
+    #         women_averager = Averager()
+    #         for result in self.results:
+    #             men_averager.add(result.men[level])
+    #             women_averager.add(result.women[level])
+
+    #         total_employees = men_averager.get_total() + women_averager.get_total()
+    #         men_percentage = 100 * men_averager.get_total() / total_employees
+    #         women_percentage = 100 * women_averager.get_total() / total_employees
+
+    #         men_append(men_percentage)
+    #         women_append(women_percentage)
+
+    #         summary = "%d\t%.2f\t%.2f" %(level + 1, men_percentage, women_percentage)
+    #         print summary
+
+    def print_summary(self):
+        """Print summary"""
+        print("Level\tMen\tWomen")
+        print("%\t\t%")
+        print("-----\t-----------------")
+
+        men_data = []
+        women_data = []
+        # Setting append constructs here, saves compute time in loop
+        men_append = men_data.append 
+        women_append = women_data.append
+
+
+        for level in range(0, self.num_levels):
+            men_total = 0
+            women_total = 0
+            for result in self.results:
+                men_total += result.men[level]
+                women_total += result.women[level]
+
+            total_employees = men_total + women_total
+            men_percentage = 100 * men_total / total_employees
+            women_percentage = 100 * women_total / total_employees
+
+            men_append(men_percentage)
+            women_append(women_percentage)
+
+            summary = "%d\t%.2f\t%.2f" %(level + 1, men_percentage, women_percentage)
+            print summary
 
 
 if __name__ == "__main__": 
-    app.run() 
-    # control = Control('male', 10)
-    # control.run_simulations()
-    # results = control.fetch_results()
+    # app.run() 
+    control = Control('male', 5)
+    control.run_simulations()
+    results = control.fetch_results()
+    summary = control.print_summary()

--- a/simulation.py
+++ b/simulation.py
@@ -1,6 +1,4 @@
-import math
 # import random
-import time
 from numpy import random
 
 from employee import Employee
@@ -41,6 +39,7 @@ class Simulation:
             append = employee_list_at_level.append
             if employee_list_at_level is not None:
                 while len(employee_list_at_level) < positions:
+                    print "hiring", level
                     append(Employee(next_gender))
                     if next_gender == "female":
                         next_gender = "male"
@@ -84,69 +83,50 @@ class Simulation:
 
             self.levels_to_employees[level] = retained_employees
 
-            # indexed_employees_to_be_deleted = random.sample(num_employees_to_be_deleted)
-
-            # for i in range(num_employees_at_level):
-            #     if i not in indexed_employees_to_be_deleted:
-            #         retained_employees.append(employee_list_at_level[i])
-            # self.levels_to_employees[level] = retained_employees
-
-
-
-        # for level in range(self.num_levels):
-        #     retained_employees = []
-        #     employee_list_at_level = self.levels_to_employees.get(level)
-        #     num_employees_at_level = len(employee_list_at_level)
-        #     num_employees_to_be_deleted = int(num_employees_at_level * (self.attrition/100.0))
-        #     indexed_employees_to_be_deleted = random.sample(num_employees_to_be_deleted)
-
-        #     for i in range(num_employees_at_level):
-        #         if i not in indexed_employees_to_be_deleted:
-        #             retained_employees.append(employee_list_at_level[i])
-        #     self.levels_to_employees[level] = retained_employees
-
-
-
-
-
-    # def attrit(self):
-    #     """Looks at each employee in dictionary and randomly retains employees
-    #     based on global attrition rate"""
-    #     for level in range(self.num_levels):
-    #         updated_employee_list = [] #retained employees will be saved here
-    #         employee_list_at_level = self.levels_to_employees.get(level)
-    #         for employee in employee_list_at_level:
-    #             if random.randrange(0, 100) >= self.attrition:
-    #                 updated_employee_list.append(employee)
-
-    #         self.levels_to_employees[level] = updated_employee_list
-
-
-
     def promote(self):
-        """Looks at each level, determines the number of promotions, adds and
-        deletes employees to various levels"""
-        # start = time.clock()
-        for i in range(self.num_levels - 1):
-            prev_level = i
-            candidates = self.levels_to_employees.get(prev_level)
-            # print candidates[0].rating
-            new_level = i + 1
-            targets = self.levels_to_employees.get(new_level)
+        """Refactored version - starts at top level, completes promotion and continues on the next tier down"""
+        """Looks at every level except entry level and determines the number of promotions, adds and
+        deletes employees to each level."""
+        for i in range(self.num_levels, 1, -1):
+            current_level = i
+            prev_level = i - 1
+            candidates = self.levels_to_employees.get(prev_level - 1)
+
+            current_level_employees = self.levels_to_employees.get(current_level - 1)
 
             candidates.sort(key=lambda x: x.rating, reverse=True)
 
             num_candidates = len(candidates)
-            open_positions = self.num_positions_list[new_level] - len(targets)
+            total_positions = self.num_positions_list[current_level - 1]
+            fill_positions = len(current_level_employees)
+            open_positions = total_positions - fill_positions
             num_promotions = min(num_candidates, open_positions)
             candidates_to_promote = candidates[:num_promotions]
 
-            self.levels_to_employees[prev_level] = candidates[num_promotions:]
-            self.levels_to_employees[new_level] = targets + candidates[:num_promotions]
-            candidates = self.levels_to_employees.get(prev_level)
+            self.levels_to_employees[prev_level - 1] = candidates[num_promotions:]
+            self.levels_to_employees[current_level - 1] = current_level_employees + candidates_to_promote
 
-            targets = self.levels_to_employees.get(new_level)
-        # print time.clock() - start, "promote method time"
+
+    # def promote(self):
+    #     """ Original version - starts at entry level and moves to the top"""
+    #     """Looks at each level, determines the number of promotions, adds and
+    #     deletes employees to various levels"""
+    #     for i in range(self.num_levels - 1):
+    #         prev_level = i
+    #         candidates = self.levels_to_employees.get(prev_level)
+    #         # print candidates[0].rating
+    #         new_level = i + 1
+    #         targets = self.levels_to_employees.get(new_level)
+
+    #         candidates.sort(key=lambda x: x.rating, reverse=True)
+
+    #         num_candidates = len(candidates)
+    #         open_positions = self.num_positions_list[new_level] - len(targets)
+    #         num_promotions = min(num_candidates, open_positions)
+
+    #         self.levels_to_employees[prev_level] = candidates[num_promotions:]
+    #         self.levels_to_employees[new_level] = targets + candidates[:num_promotions]
+   
 
     def get_result(self):
         """Counts number of men and women at each level and saves totals to


### PR DESCRIPTION
Previously the promote method started at level two, filled it's open positions from employees in level one and continued these steps until it reached the top level. 
Upon closer review, I realized that starting from the bottom results in creating new openings as you continue to the top. Therefore the method should look at the top level, complete it's promotions and move down to the bottom. At the end of the method only level one should have open positions, which get filled by the hire method.
The glitch is that this approach returns very different final results then we've come to expect. 
(Both versions are viewable in this code)
I think the new version may be correct and that our results up until now we incorrect.  
