### PR TITLE
Fixing int division issue(?) and changing to normal distribution ratings

### DIFF
--- a/employee.py
+++ b/employee.py
@@ -2,6 +2,6 @@ class Employee:
 
     def __init__(self, gender):
         self.gender = gender
-        self.rating = 10
+        self.rating = 10.0
 
 

--- a/simulation.py
+++ b/simulation.py
@@ -59,7 +59,7 @@ class Simulation:
         random performance rating"""
         for employee_list in self.levels_to_employees.values(): 
             for employee in employee_list:
-                new_rating = random.randint(0, 10)
+                new_rating = random.normal(10, 1)
                 bias = (self.promotion_bias/100.0) + 1
                 # print "bias calculation", bias
                 if employee.gender == self.bias_favors_this_gender:


### PR DESCRIPTION
I forked this because I wanted to discover what results I would get if I used the same org structure and promotion selection criteria as my employer.

When tinkering with the values I think I’ve discovered a bug that adds an extra advantage to the favoured gender.  It comes down to the way that previous results are added to the most recent performance score during the talent review.  

The code looks like it expects to add half of the previous score the current rating.  But since the initial rating is an integer and the previous rating is calculated:
previous_rating = employee.rating/2
When employ.rating is an odd integer the result rounded down, e.g. 5/2 = 2
After the first talent review, all favoured gender people’s rating is a float due to them gaining a bias.
Hence un-favoured people perpetually get less benefit from their previous rating whenever it is odd.

If employee.rating is changed to a float e.g. in the class definition:
self.rating = 10.0
The unplanned advantage to favoured people goes away and with an 1% bias averaged over hundreds of runs the ratio is more like 54:46 (disappointing).

HOWEVER, I tried changing the new random rating to use "bell curve" normal distribution as per the original paper.  This brought the bias up to 65:35 for 1%.  For 5 and 10, the impact is  much higher.  Perhaps a larger standard deviation on the bell curve would lessen this.

So if you accept this PR, I think it fixes a bug and still makes the point.  

Sorry for making trouble!